### PR TITLE
allow variation to be array

### DIFF
--- a/spec/components/Feature.spec.js
+++ b/spec/components/Feature.spec.js
@@ -17,7 +17,7 @@ describe('Feature', () => {
     expect(feature.find('#match').length).toBe(1);
   });
 
-  it('will render children if variation prop is set to the correct value', () => {
+  it('will render children if variation prop is set to the flag value', () => {
     const feature = shallow(
       <Feature variation={ true }>
         <div id="match">Hello</div>
@@ -26,9 +26,27 @@ describe('Feature', () => {
     expect(feature.find('#match').length).toBe(1);
   });
 
-  it('will not render children if variation prop is set to the incorrect value', () => {
+  it('will not render children if variation prop is set to the incorrect flag value', () => {
     const feature = shallow(
       <Feature variation={ false }>
+        <div id="match">Hello</div>
+      </Feature>
+    );
+    expect(feature.find('#match').length).toBe(0);
+  });
+
+  it('will render children if varation prop is an array and includes the flag value', () => {
+    const feature = shallow(
+      <Feature variation={ [true, 'test'] }>
+        <div id="match">Hello</div>
+      </Feature>
+    );
+    expect(feature.find('#match').length).toBe(1);
+  });
+
+  it('will not ender children if varation prop is an array and does not include the flag value', () => {
+    const feature = shallow(
+      <Feature variation={ [false, 'test'] }>
         <div id="match">Hello</div>
       </Feature>
     );

--- a/spec/components/VariantRenderer.spec.js
+++ b/spec/components/VariantRenderer.spec.js
@@ -47,4 +47,22 @@ describe('VariantRenderer', () => {
     expect(feature.find('#match').length).toBe(1);
     expect(feature2.find('#match').length).toBe(1);
   });
+
+  it('will render children if varation prop is an array and includes the flag value', () => {
+    const feature = shallow(
+      <VariantRenderer flagValue={ true } variation={ ['test', true] }>
+        <div id="match">Hello</div>
+      </VariantRenderer>
+    );
+    expect(feature.find('#match').length).toBe(1);
+  });
+
+  it('will not ender children if varation prop is an array and does not include the flag value', () => {
+    const feature = shallow(
+      <VariantRenderer flagValue={ true } variation={ ['test', false] }>
+        <div id="match">Hello</div>
+      </VariantRenderer>
+    );
+    expect(feature.find('#match').length).toBe(0);
+  });
 });

--- a/src/components/Feature.js
+++ b/src/components/Feature.js
@@ -8,10 +8,14 @@ export class Feature extends Component {
   render() {
     const { children, flagId, variation, flags } = this.props;
 
+    let variationMatch = false;
+    if (Array.isArray(variation)) {
+      variationMatch = variation.includes(flags[flagId]);
+    } else if (['string', 'boolean', 'null'].includes(typeof variation)) {
+      variationMatch = flags[flagId] === variation;
+    }
     const renderNode =
-      variation !== undefined
-        ? flags[flagId] === variation && children
-        : children;
+      variation !== undefined ? variationMatch && children : children;
 
     return (
       <FlagContext.Provider value={ flags[flagId] }>

--- a/src/components/VariantRenderer.js
+++ b/src/components/VariantRenderer.js
@@ -4,7 +4,14 @@ import PropTypes from 'prop-types';
 class VariantRenderer extends Component {
   render() {
     const { children, flagValue, variation, isDefault } = this.props;
-    const variationMatch = variation !== undefined && flagValue === variation;
+
+    let variationMatch = false;
+    if (Array.isArray(variation)) {
+      variationMatch = variation.includes(flagValue);
+    } else if (['string', 'boolean', 'null'].includes(typeof variation)) {
+      variationMatch = flagValue === variation;
+    }
+
     const isDefaultMatch = [null, undefined].includes(flagValue) && isDefault;
     {
       if (variationMatch || isDefaultMatch) {


### PR DESCRIPTION
allows for both `<Feature />` and `<Variant>` to accept a `variant prop as an array to match multiple flag values for an individual component