### PR TITLE
Make children unrequired for all components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ld-redux-components",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description":
     "Launch Darkly Helper Components that leverage redux",
   "main": "build/index.js",

--- a/spec/components/Feature.spec.js
+++ b/spec/components/Feature.spec.js
@@ -52,4 +52,11 @@ describe('Feature', () => {
     );
     expect(feature.find('#match').length).toBe(0);
   });
+
+  it('will not break if no children are provided', () => {
+    const feature = shallow(
+      <Feature variation={ true } />
+    );
+
+  });
 });

--- a/spec/components/Feature.spec.js
+++ b/spec/components/Feature.spec.js
@@ -57,6 +57,5 @@ describe('Feature', () => {
     const feature = shallow(
       <Feature variation={ true } />
     );
-
   });
 });

--- a/spec/components/Feature.spec.js
+++ b/spec/components/Feature.spec.js
@@ -44,7 +44,7 @@ describe('Feature', () => {
     expect(feature.find('#match').length).toBe(1);
   });
 
-  it('will not ender children if varation prop is an array and does not include the flag value', () => {
+  it('will not render children if varation prop is an array and does not include the flag value', () => {
     const feature = shallow(
       <Feature variation={ [false, 'test'] }>
         <div id="match">Hello</div>

--- a/spec/components/Feature.spec.js
+++ b/spec/components/Feature.spec.js
@@ -54,7 +54,7 @@ describe('Feature', () => {
   });
 
   it('will not break if no children are provided', () => {
-    const feature = shallow(
+    shallow(
       <Feature variation={ true } />
     );
   });

--- a/spec/components/Variant.spec.js
+++ b/spec/components/Variant.spec.js
@@ -20,10 +20,10 @@ describe('Variant', () => {
   });
 
   it('will not break if children are not present', () => {
-    const wrapper = shallow(
+    shallow(
       <Feature>
         <Variant variation={ true } />
       </Feature>
     );
-  })
+  });
 });

--- a/spec/components/Variant.spec.js
+++ b/spec/components/Variant.spec.js
@@ -22,7 +22,7 @@ describe('Variant', () => {
   it('will not break if children are not present', () => {
     const wrapper = shallow(
       <Feature>
-      <Variant variation={ true } />
+        <Variant variation={ true } />
       </Feature>
     );
   })

--- a/spec/components/Variant.spec.js
+++ b/spec/components/Variant.spec.js
@@ -1,6 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { Feature } from '../../src/components/Feature';
 import Variant from '../../src/components/Variant';
+
+Feature.defaultProps = {
+  flagId: 'testFlag',
+  flags: { testFlag: true },
+};
 
 describe('Variant', () => {
   // THIS CANNOT BE TESTED UNTIL https://github.com/airbnb/enzyme/pull/1513 is released
@@ -12,4 +18,12 @@ describe('Variant', () => {
     );
     expect(wrapper.props('flagValue')).to.equal(true);
   });
+
+  it('will not break if children are not present', () => {
+    const wrapper = shallow(
+      <Feature>
+      <Variant variation={ true } />
+      </Feature>
+    );
+  })
 });

--- a/spec/components/VariantRenderer.spec.js
+++ b/spec/components/VariantRenderer.spec.js
@@ -65,4 +65,11 @@ describe('VariantRenderer', () => {
     );
     expect(feature.find('#match').length).toBe(0);
   });
+
+  it('will not break if no children are provided', () => {
+    const feature = shallow(
+      <VariantRenderer flagValue={ true } variation={ true } />
+    );
+
+  });
 });

--- a/spec/components/VariantRenderer.spec.js
+++ b/spec/components/VariantRenderer.spec.js
@@ -67,7 +67,7 @@ describe('VariantRenderer', () => {
   });
 
   it('will not break if no children are provided', () => {
-    const feature = shallow(
+    shallow(
       <VariantRenderer flagValue={ true } variation={ true } />
     );
 

--- a/src/components/Feature.js
+++ b/src/components/Feature.js
@@ -26,7 +26,7 @@ export class Feature extends Component {
 }
 
 Feature.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   flagId: PropTypes.string.isRequired,
   variation: PropTypes.any,
   flags: PropTypes.object.isRequired,

--- a/src/components/Variant.js
+++ b/src/components/Variant.js
@@ -14,7 +14,7 @@ class Variant extends Component {
 }
 
 Variant.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   variation: PropTypes.any,
   isDefault: PropTypes.bool,
 };

--- a/src/components/VariantRenderer.js
+++ b/src/components/VariantRenderer.js
@@ -24,7 +24,7 @@ class VariantRenderer extends Component {
 }
 
 VariantRenderer.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   flagValue: PropTypes.any,
   variation: PropTypes.any,
   isDefault: PropTypes.bool,


### PR DESCRIPTION
Currently, the `children` prop for `Feature` and `Variant` components must be present. This is problematic because it limits developers from using conditional blocks directly underneath these components, and requires ugly workarounds to meet functional requirements.

This PR makes the `children` prop optional to allow for these types of implementations.