### PR TITLE
add onReady and waitForLD props on Feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ld-redux-components",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description":
     "Launch Darkly Helper Components that leverage redux",
   "main": "build/index.js",

--- a/spec/components/Feature.spec.js
+++ b/spec/components/Feature.spec.js
@@ -58,4 +58,33 @@ describe('Feature', () => {
       <Feature variation={ true } />
     );
   });
+
+  it('will call onReady when launch darkly server has connected', () => {
+    const onReadySpy = jest.fn();
+    const wrapper = shallow(
+      <Feature onReady={ onReadySpy } flags={ { isLDReady: false } } />
+    );
+    expect(onReadySpy).toHaveBeenCalledTimes(0);
+    wrapper.setProps({ flags: { isLDReady: true } });
+    expect(onReadySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('will call onReady when launch darkly server is connected only once', () => {
+    const onReadySpy = jest.fn();
+    shallow(
+      <Feature onReady={ onReadySpy } flags={ { isLDReady: true } } />
+    );
+    expect(onReadySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('will not render until ld server connects when "waitForLD" prop is set to true', () => {
+    const wrapper = shallow(
+      <Feature waitForLD flags={ { isLDReady: false } } >
+        <div id="match">Hello</div>
+      </Feature>
+    );
+    expect(wrapper.find('#match').length).toBe(0);
+    wrapper.setProps({ flags: { isLDReady: true } });
+    expect(wrapper.find('#match').length).toBe(1);
+  });
 });

--- a/src/components/Feature.js
+++ b/src/components/Feature.js
@@ -5,8 +5,24 @@ import FlagContext from '../utils/FlagContext';
 import Config from '../config';
 
 export class Feature extends Component {
+  componentDidMount() {
+    if (this.props.flags.isLDReady && this.props.onReady) {
+      this.props.onReady();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      !prevProps.flags.isLDReady &&
+      this.props.flags.isLDReady &&
+      this.props.onReady
+    ) {
+      this.props.onReady();
+    }
+  }
+
   render() {
-    const { children, flagId, variation, flags } = this.props;
+    const { children, flagId, variation, flags, waitForLD } = this.props;
 
     let variationMatch = false;
     if (Array.isArray(variation)) {
@@ -14,8 +30,11 @@ export class Feature extends Component {
     } else if (['string', 'boolean', 'null'].includes(typeof variation)) {
       variationMatch = flags[flagId] === variation;
     }
-    const renderNode =
+
+    let renderNode =
       variation !== undefined ? variationMatch && children : children;
+
+    renderNode = waitForLD ? flags.isLDReady && renderNode : renderNode;
 
     return (
       <FlagContext.Provider value={ flags[flagId] }>
@@ -30,6 +49,8 @@ Feature.propTypes = {
   flagId: PropTypes.string.isRequired,
   variation: PropTypes.any,
   flags: PropTypes.object.isRequired,
+  onReady: PropTypes.func,
+  waitForLD: PropTypes.bool,
 };
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
**What**
For the `Feature` component,
1. Added `onReady` prop --> fires after LD connection is established.
2. Added `waitForLD` prop --> holds off on rendering children until LD connection is established.

**Why**
In certain scenarios, it is helpful to ensure that LD is connected to the server and has set the proper flags for the user before calling certain functions. This is particularly helpful in cases where you want to call functions early in the application lifecycle (e.g. initial page load) but are highly dependent on the proper flag value for the user (such as event tracking). This MR adds an `onReady` callback that fires based on two possible scenarios,

1. `Feature` mounts and `isLDReady` redux value is set to true, or
2. `Feature` is already mounted and `isLDReady` redux value changes from false to true

Additionally, this MR adds the ability for a `Feature` to hold off on rendering children until LD is connected. This is particularly important if you want to ensure that the user does not see a variant they should not see. Note that if ld does not connect, this will likely result in nothing being rendered.