### PR TITLE
Feature/live update prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ld-redux-components",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description":
     "Launch Darkly Helper Components that leverage redux",
   "main": "build/index.js",

--- a/spec/components/Feature.spec.js
+++ b/spec/components/Feature.spec.js
@@ -5,6 +5,7 @@ import { Feature } from '../../src/components/Feature';
 Feature.defaultProps = {
   flagId: 'testFlag',
   flags: { testFlag: true },
+  liveUpdate: true,
 };
 
 describe('Feature', () => {
@@ -86,5 +87,33 @@ describe('Feature', () => {
     expect(wrapper.find('#match').length).toBe(0);
     wrapper.setProps({ flags: { isLDReady: true } });
     expect(wrapper.find('#match').length).toBe(1);
+  });
+
+  it('will rerender the component if liveUpdate prop is set to true, and a flag is changed after initial load', () => {
+    const mock = jest.spyOn(Feature.prototype, 'render').mockImplementation(() => null);
+    const wrapper = shallow(
+      <Feature flags={ { isLDReady: true } } >
+        <div id="match">Hello</div>
+      </Feature>
+    );
+    
+    expect(Feature.prototype.render).toHaveBeenCalledTimes(1);
+    wrapper.setProps({ flags: { testFlag: false } });
+    expect(Feature.prototype.render).toHaveBeenCalledTimes(2);
+    mock.mockReset();
+  });
+
+  it('will not rerender the component if liveUpdate prop is set to false, and a flag is changed after initial load', () => {
+    const mock = jest.spyOn(Feature.prototype, 'render').mockImplementation(() => null);
+    const wrapper = shallow(
+      <Feature flags={ { isLDReady: true } } liveUpdate={ false } >
+        <div id="match">Hello</div>
+      </Feature>
+    );
+    
+    expect(Feature.prototype.render).toHaveBeenCalledTimes(1);
+    wrapper.setProps({ flags: { testFlag: false } });
+    expect(Feature.prototype.render).toHaveBeenCalledTimes(1);
+    mock.mockReset();
   });
 });

--- a/src/components/Feature.js
+++ b/src/components/Feature.js
@@ -21,6 +21,18 @@ export class Feature extends Component {
     }
   }
 
+  shouldComponentUpdate(nextProps) {
+    const { liveUpdate } = this.props;
+    if (liveUpdate || nextProps.liveUpdate) {
+      return true;
+    }
+    //either on initial load, or the first load
+    if (!this.props.flags.isLDReady) {
+      return true;
+    }
+    return false;
+  }
+
   render() {
     const { children, flagId, variation, flags, waitForLD } = this.props;
 
@@ -53,6 +65,11 @@ Feature.propTypes = {
   flags: PropTypes.object.isRequired,
   onReady: PropTypes.func,
   waitForLD: PropTypes.bool,
+  liveUpdate: PropTypes.bool,
+};
+
+Feature.defaultProps = {
+  liveUpdate: true,
 };
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
This adds the ability to not rerender a `Feature` component if a flag value changes _after_ the initial LD load and flag set